### PR TITLE
Allow manual specification of host_ip and guest_ip

### DIFF
--- a/lib/vagrant-nfs_guest/config.rb
+++ b/lib/vagrant-nfs_guest/config.rb
@@ -6,6 +6,8 @@ module VagrantPlugins
       attr_accessor :functional
       attr_accessor :map_uid
       attr_accessor :map_gid
+      attr_accessor :host_ip
+      attr_accessor :guest_ip
 
       def initialize
         super
@@ -13,12 +15,16 @@ module VagrantPlugins
         @functional = UNSET_VALUE
         @map_uid    = UNSET_VALUE
         @map_gid    = UNSET_VALUE
+        @host_ip    = UNSET_VALUE
+        @guest_ip   = UNSET_VALUE
       end
 
       def finalize!
         @functional = true if @functional == UNSET_VALUE
         @map_uid = nil if @map_uid == UNSET_VALUE
         @map_gid = nil if @map_gid == UNSET_VALUE
+        @host_ip = nil if @host_ip == UNSET_VALUE
+        @guest_ip = nil if @guest_ip == UNSET_VALUE
       end
 
       def to_s

--- a/lib/vagrant-nfs_guest/guests/linux/cap/nfs_export.rb
+++ b/lib/vagrant-nfs_guest/guests/linux/cap/nfs_export.rb
@@ -106,10 +106,7 @@ module VagrantPlugins
             # by Vagrant
             #
             machine.communicate.sudo(
-              "sed -r -e '/^# VAGRANT-BEGIN:( #{user})? #{id}/,/^# " +
-              "VAGRANT-END:( #{user})? #{id}/ d' -ibak /etc/exports",
-              error_class: Errors::GuestNFSError,
-              error_key: :nfs_guest_clean
+              "sed -r -e '/^# VAGRANT(-NFS_GUEST)?-BEGIN/,/^# VAGRANT(-NFS_GUEST)?-END/ d' -ibak /etc/exports"
             )
           end
 

--- a/lib/vagrant-nfs_guest/guests/linux/cap/nfs_export.rb
+++ b/lib/vagrant-nfs_guest/guests/linux/cap/nfs_export.rb
@@ -106,7 +106,9 @@ module VagrantPlugins
             # by Vagrant
             #
             machine.communicate.sudo(
-              "sed -r -e '/^# VAGRANT(-NFS_GUEST)?-BEGIN/,/^# VAGRANT(-NFS_GUEST)?-END/ d' -ibak /etc/exports"
+              "sed -r -e '/^# VAGRANT(-NFS_GUEST)?-BEGIN/,/^# VAGRANT(-NFS_GUEST)?-END/ d' -ibak /etc/exports",
+              error_class: Errors::GuestNFSError,
+              error_key: :nfs_guest_clean
             )
           end
 

--- a/lib/vagrant-nfs_guest/synced_folder.rb
+++ b/lib/vagrant-nfs_guest/synced_folder.rb
@@ -15,18 +15,8 @@ module VagrantPlugins
       end
 
       def enable(machine, folders, nfsopts)
-        raise Vagrant::Errors::NFSNoHostIP if !nfsopts[:nfs_guest_host_ip]
-        raise Vagrant::Errors::NFSNoGuestIP if !nfsopts[:nfs_guest_machine_ip]
-
-        if machine.guest.capability?(:nfs_server_installed)
-          installed = machine.guest.capability(:nfs_server_installed)
-          if !installed
-            can_install = machine.guest.capability?(:nfs_server_install)
-            raise Errors::NFSServerNotInstalledInGuest if !can_install
-            machine.ui.info I18n.t("vagrant_nfs_guest.guests.linux.nfs_server_installing")
-            machine.guest.capability(:nfs_server_install)
-          end
-        end
+        verify_nfs_options(folders, nfsopts)
+        verify_nfs_installation(machine) if machine.guest.capability?(:nfs_server_installed)
 
         machine_ip = nfsopts[:nfs_guest_machine_ip]
         machine_ip = [machine_ip] if !machine_ip.is_a?(Array)
@@ -78,6 +68,39 @@ module VagrantPlugins
         # Get UID/GID from guests user if we've made it this far
         # (value == :auto)
         return machine.guest.capability("read_#{perm}".to_sym)
+      end
+
+      private
+
+      def verify_nfs_installation(machine)
+        if !machine.guest.capability(:nfs_server_installed)
+          raise Errors::NFSServerNotInstalledInGuest unless machine.guest.capability?(:nfs_server_install)
+
+          machine.ui.info I18n.t("vagrant_nfs_guest.guests.linux.nfs_server_installing")
+          machine.guest.capability(:nfs_server_install)
+        end
+      end
+
+      def verify_nfs_options(folders, nfsopts = {})
+        if !nfsopts[:nfs_guest_host_ip]
+          if folder = folders.detect { |_, v| !!v[:host_ip] }
+            nfsopts[:nfs_guest_host_ip] = folder[1][:host_ip]
+          end
+
+          raise Vagrant::Errors::NFSNoHostIP if !nfsopts[:nfs_guest_host_ip]
+        end
+
+        if !nfsopts[:nfs_guest_machine_ip]
+          if folder = folders.detect { |_, v| !!extract_guest_ip(v) }
+            nfsopts[:nfs_guest_machine_ip] = extract_guest_ip(folder[1])
+          end
+
+          raise Vagrant::Errors::NFSNoGuestIP if !nfsopts[:nfs_guest_machine_ip]
+        end
+      end
+
+      def extract_guest_ip(folder)
+        folder[:guest_ip] || folder[:machine_ip]
       end
     end
   end

--- a/lib/vagrant-nfs_guest/synced_folder.rb
+++ b/lib/vagrant-nfs_guest/synced_folder.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
       end
 
       def enable(machine, folders, nfsopts)
-        verify_nfs_options(folders, nfsopts)
+        verify_nfs_options(machine, nfsopts)
         verify_nfs_installation(machine) if machine.guest.capability?(:nfs_server_installed)
 
         machine_ip = nfsopts[:nfs_guest_machine_ip]
@@ -81,18 +81,18 @@ module VagrantPlugins
         end
       end
 
-      def verify_nfs_options(folders, nfsopts = {})
+      def verify_nfs_options(machine, nfsopts = {})
         if !nfsopts[:nfs_guest_host_ip]
-          if folder = folders.detect { |_, v| !!v[:host_ip] }
-            nfsopts[:nfs_guest_host_ip] = folder[1][:host_ip]
+          if machine.config.nfs_guest.host_ip
+            nfsopts[:nfs_guest_host_ip] = machine.config.nfs_guest.host_ip
           end
 
           raise Vagrant::Errors::NFSNoHostIP if !nfsopts[:nfs_guest_host_ip]
         end
 
         if !nfsopts[:nfs_guest_machine_ip]
-          if folder = folders.detect { |_, v| !!extract_guest_ip(v) }
-            nfsopts[:nfs_guest_machine_ip] = extract_guest_ip(folder[1])
+          if machine.config.nfs_guest.guest_ip
+            nfsopts[:nfs_guest_machine_ip] = machine.config.nfs_guest.guest_ip
           end
 
           raise Vagrant::Errors::NFSNoGuestIP if !nfsopts[:nfs_guest_machine_ip]

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -48,3 +48,6 @@ en:
 
       nfs_server_not_installed: |-
         Guest cannot install the required NFS server daemon.
+
+      nfs_guest_clean: |-
+        Something failed while cleaning up NFS shared folders on the guest.

--- a/templates/nfs_guest/guest_export_linux.erb
+++ b/templates/nfs_guest/guest_export_linux.erb
@@ -1,7 +1,7 @@
-# VAGRANT-BEGIN: <%= user %> <%= uuid %>
+# VAGRANT-NFS_GUEST-BEGIN
 <% ips.each do |ip| %>
 <% folders.each do |dirs, opts| %>
 "<%= opts[:guestpath] %>" <%= ip %>(<%= opts[:linux__nfs_options].join(",") %>)
 <% end %>
 <% end %>
-# VAGRANT-END: <%= user %> <%= uuid %>
+# VAGRANT-NFS_GUEST-END


### PR DESCRIPTION
This shuffles a few things into private methods, as well as adds configuration variables for the host and guest IP since these can be known beforehand.

This also allows the VMware Fusion plugin to be used when using static IPs since the PrepareNFSGuestSettings middleware is only used/compatible with Virtualbox.