### PR TITLE
Add support for custom owners and groups. 

### DIFF
--- a/lib/vagrant-nfs_guest/guests/linux/cap/nfs_export.rb
+++ b/lib/vagrant-nfs_guest/guests/linux/cap/nfs_export.rb
@@ -142,8 +142,13 @@ module VagrantPlugins
                   error_class: Errors::GuestNFSError,
                   error_key: :nfs_create_mounts_failed
                 )
+
+                # Folder options
+                opts[:owner] ||= machine.ssh_info[:username]
+                opts[:group] ||= machine.ssh_info[:username]
+
                 machine.communicate.sudo(
-                  "chown -R vagrant:vagrant #{expanded_guest_path}",
+                  "chown -R #{opts[:owner]}:#{opts[:group]} #{expanded_guest_path}",
                   error_class: Errors::GuestNFSError,
                   error_key: :nfs_create_mounts_failed
                 )


### PR DESCRIPTION
Leverage the SSH user if none are specified. Replaces vagrant/vagrant.

I ran into a problem where the code as is was failing on my base images because I was not using the standard "vagrant" user. This pull request follows the vagrant model of the user/group being specified in the shared folder, or just defaulting to the one used in the SSH connection.