### PR TITLE
Custom host mount/unmount options

### DIFF
--- a/lib/vagrant-nfs_guest/hosts/bsd/cap/mount_nfs.rb
+++ b/lib/vagrant-nfs_guest/hosts/bsd/cap/mount_nfs.rb
@@ -15,8 +15,11 @@ module VagrantPlugins
                                  guestpath: opts[:guestpath],
                                  hostpath: opts[:hostpath]))
 
+                mount_options = opts.fetch(:mount_options, ["noatime"])
+                nfs_options = mount_options.empty? ? "" : "-o #{mount_options.join(',')}"
+
                 system("mkdir -p #{opts[:hostpath]}")
-                mount_command = "mount -t nfs -o noatime '#{ip}:#{opts[:guestpath]}' '#{opts[:hostpath]}'"
+                mount_command = "mount -t nfs #{nfs_options} '#{ip}:#{opts[:guestpath]}' '#{opts[:hostpath]}'"
                 if system(mount_command)
                   break
                 end

--- a/lib/vagrant-nfs_guest/hosts/bsd/cap/unmount_nfs.rb
+++ b/lib/vagrant-nfs_guest/hosts/bsd/cap/unmount_nfs.rb
@@ -14,8 +14,10 @@ module VagrantPlugins
                                guestpath: opts[:guestpath],
                                hostpath: opts[:hostpath]))
 
+              unmount_options = opts.fetch(:unmount_options, []).join(" ")
+
               expanded_host_path = `printf #{opts[:hostpath]}`
-              umount_msg = `umount '#{expanded_host_path}' 2>&1`
+              umount_msg = `umount #{unmount_options} '#{expanded_host_path}' 2>&1`
 
               if $?.exitstatus != 0
                 if not umount_msg.include? 'not currently mounted'

--- a/lib/vagrant-nfs_guest/hosts/linux/cap/mount_nfs.rb
+++ b/lib/vagrant-nfs_guest/hosts/linux/cap/mount_nfs.rb
@@ -15,8 +15,11 @@ module VagrantPlugins
                                  guestpath: opts[:guestpath],
                                  hostpath: opts[:hostpath]))
 
+                mount_options = opts.fetch(:mount_options, ["noatime"])
+                nfs_options = mount_options.empty? ? "" : "-o #{mount_options.join(',')}"
+
                 system("mkdir -p #{opts[:hostpath]}")
-                mount_command = "sudo mount -t nfs -o noatime '#{ip}:#{opts[:guestpath]}' '#{opts[:hostpath]}'"
+                mount_command = "sudo mount -t nfs #{nfs_options} '#{ip}:#{opts[:guestpath]}' '#{opts[:hostpath]}'"
                 if system(mount_command)
                   break
                 end

--- a/lib/vagrant-nfs_guest/hosts/linux/cap/unmount_nfs.rb
+++ b/lib/vagrant-nfs_guest/hosts/linux/cap/unmount_nfs.rb
@@ -14,8 +14,10 @@ module VagrantPlugins
                                guestpath: opts[:guestpath],
                                hostpath: opts[:hostpath]))
 
+              unmount_options = opts.fetch(:unmount_options, []).join(" ")
+
               expanded_host_path = `printf #{opts[:hostpath]}`
-              umount_msg = `sudo umount '#{expanded_host_path}' 2>&1`
+              umount_msg = `sudo umount #{unmount_options} '#{expanded_host_path}' 2>&1`
 
               if $?.exitstatus != 0
                 if not umount_msg.include? 'not currently mounted'


### PR DESCRIPTION
This PR allows the Linux and BSD hosts to specify custom options to pass to `mount` and `umount` via the `:mount_options` and `:unmount_options` options for `vm.synced_folder`.  I added this in order to allow myself to pass the `-f` option to `umount`, and figured that I might as well generalize this sort of customization and submit a PR!