### PR TITLE
Add missing error text

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -43,6 +43,16 @@ en:
 
         Stderr from the command:
         %{stderr}
+      nfs_create_mounts_failed: |-
+        Something failed while creating the NFS mounts on the guest.
+
+        %{command}
+
+        Stdout from the command:
+        %{stdout}
+
+        Stderr from the command:
+        %{stderr}
 
       nfs_server_missing: |-
         Guest is missing the required NFS server daemon.


### PR DESCRIPTION
I was messing with the mounting options on the guest, and managed to cause an error, which revealed that the `nfs_create_mounts_failed` error was not actually defined in the lexicon.  This PR just adds text for it that follows the pattern established by similar errors.