### PR TITLE
add provider support for lxc

### DIFF
--- a/lib/vagrant-nfs_guest/plugin.rb
+++ b/lib/vagrant-nfs_guest/plugin.rb
@@ -19,6 +19,7 @@ require_relative "hosts/linux/plugin"
 require_relative "providers/virtualbox/plugin"
 require_relative "providers/parallels/plugin"
 require_relative "providers/docker/plugin"
+require_relative "providers/lxc/plugin"
 
 module VagrantPlugins
   module SyncedFolderNFSGuest

--- a/lib/vagrant-nfs_guest/providers/lxc/cap/nfs_settings.rb
+++ b/lib/vagrant-nfs_guest/providers/lxc/cap/nfs_settings.rb
@@ -1,0 +1,23 @@
+module VagrantPlugins
+  module SyncedFolderNFSGuest
+    module ProviderLxc
+      module Cap
+
+	def self.read_host_ip(machine)
+          machine.communicate.execute 'echo $SSH_CLIENT' do |buffer, output|
+            return output.chomp.split(' ')[0] if buffer == :stdout
+	  end
+	end
+
+        def self.nfs_settings(machine)
+          host_ip  = self.read_host_ip(machine)
+          machine_ip = machine.provider.ssh_info[:host]
+
+          raise Vagrant::Errors::NFSNoHostonlyNetwork if !host_ip || !machine_ip
+
+          return host_ip, machine_ip
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-nfs_guest/providers/lxc/plugin.rb
+++ b/lib/vagrant-nfs_guest/providers/lxc/plugin.rb
@@ -1,0 +1,15 @@
+require "vagrant"
+
+module VagrantPlugins
+  module SyncedFolderNFSGuest
+    class Plugin < Vagrant.plugin("2")
+      name "lxc-provider"
+      description "vagrant-lxc provider"
+
+      provider_capability(:lxc, :nfs_settings) do
+        require_relative "cap/nfs_settings"
+        ProviderLxc::Cap
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add vagrant-lxc provider support.

Looks like:
```
hypernode-vagrant$ vagrant up --provider=lxc
Bringing machine 'hypernode' up with 'lxc' provider...
...
==> hypernode: Setting up mount entries for shared folders...
    hypernode: /vagrant => /home/vdloo/code/projects/hypernode-vagrant
==> hypernode: Starting container...
==> hypernode: Waiting for machine to boot. This may take a few minutes...
    hypernode: SSH address: 10.0.3.23:22
    hypernode: SSH username: vagrant
    hypernode: SSH auth method: private key
    hypernode: 
    hypernode: Vagrant insecure key detected. Vagrant will automatically replace
    hypernode: this with a newly generated keypair for better security.
    hypernode: 
    hypernode: Inserting generated public key within guest...
    hypernode: Removing insecure key from the guest if it's present...
    hypernode: Key inserted! Disconnecting and reconnecting using new SSH key...
==> hypernode: Machine booted and ready!
==> hypernode: Setting hostname...
==> hypernode: Installing nfs server on the guest...
==> hypernode: Exporting NFS shared folders from guest...
==> hypernode: Preparing to edit /etc/exports on the guest...
==> hypernode: Mounting NFS shared folders from guest...
    hypernode: /data/web/magento2 => data/web/magento2
    hypernode: /data/web/nginx => data/web/nginx/
==> hypernode: Updating /etc/hosts file on active guest machines...
==> hypernode: Updating /etc/hosts file on host machine (password may be required)...
==> hypernode: Running provisioner: shell...
    hypernode: Running: /tmp/vagrant-shell20160809-2432-ldedod.sh
...
```

Note: on Ubuntu with apparmor you need to do this in the lxc.conf of your box
```
# When using LXC with apparmor, uncomment the next line to run unconfined:
lxc.aa_profile = unconfined
```

Or installing the nfs server on the guest will fail with this error:
```
==> hypernode: Installing nfs server on the guest...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

apt-get -y install nfs-kernel-server

Stdout from the command:

Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  libgssglue1 libnfsidmap2 libtirpc1 nfs-common rpcbind
The following NEW packages will be installed:
  libgssglue1 libnfsidmap2 libtirpc1 nfs-common nfs-kernel-server rpcbind
0 upgraded, 6 newly installed, 0 to remove and 7 not upgraded.
Need to get 547 kB of archives.
After this operation, 1,923 kB of additional disk space will be used.
Get:1 http://ubuntu.byte.nl/ precise/main libgssglue1 amd64 0.3-4ubuntu0.1 [22.5 kB]
Get:2 http://ubuntu.byte.nl/ precise/main libtirpc1 amd64 0.2.2-5 [84.2 kB]
Get:3 http://ubuntu.byte.nl/ precise/main libnfsidmap2 amd64 0.25-1ubuntu2 [32.0 kB]
Get:4 http://security.ubuntu.com/ubuntu/ precise-security/main rpcbind amd64 0.2.0-7ubuntu1.3 [43.1 kB]
Get:5 http://ubuntu.byte.nl/ precise/main nfs-common amd64 1:1.2.5-3ubuntu3.1 [241 kB]
Get:6 http://ubuntu.byte.nl/ precise/main nfs-kernel-server amd64 1:1.2.5-3ubuntu3.1 [124 kB]
Fetched 547 kB in 0s (2,943 kB/s)
Selecting previously unselected package libgssglue1.
(Reading database ... 32250 files and directories currently installed.)
Unpacking libgssglue1 (from .../libgssglue1_0.3-4ubuntu0.1_amd64.deb) ...
Selecting previously unselected package libtirpc1.
Unpacking libtirpc1 (from .../libtirpc1_0.2.2-5_amd64.deb) ...
Selecting previously unselected package rpcbind.
Unpacking rpcbind (from .../rpcbind_0.2.0-7ubuntu1.3_amd64.deb) ...
Selecting previously unselected package libnfsidmap2.
Unpacking libnfsidmap2 (from .../libnfsidmap2_0.25-1ubuntu2_amd64.deb) ...
Selecting previously unselected package nfs-common.
Unpacking nfs-common (from .../nfs-common_1%3a1.2.5-3ubuntu3.1_amd64.deb) ...
Selecting previously unselected package nfs-kernel-server.
Unpacking nfs-kernel-server (from .../nfs-kernel-server_1%3a1.2.5-3ubuntu3.1_amd64.deb) ...
Processing triggers for man-db ...
Processing triggers for ureadahead ...
Setting up libgssglue1 (0.3-4ubuntu0.1) ...
Setting up libtirpc1 (0.2.2-5) ...
Setting up rpcbind (0.2.0-7ubuntu1.3) ...
 Removing any system startup links for /etc/init.d/rpcbind ...
portmap start/running, process 4100
Setting up libnfsidmap2 (0.25-1ubuntu2) ...
Setting up nfs-common (1:1.2.5-3ubuntu3.1) ...
Adding system user `statd' (UID 113) ...
Adding new user `statd' (UID 113) with group `nogroup' ...
Not creating home directory `/var/lib/nfs'.
statd start/running, process 4334
gssd stop/pre-start, process 4363
idmapd start/running, process 4403
Setting up nfs-kernel-server (1:1.2.5-3ubuntu3.1) ...
 * Exporting directories for NFS kernel daemon...
   ...done.
 * Starting NFS kernel daemon
   ...fail!
Processing triggers for libc-bin ...
ldconfig deferred processing now taking place


Stderr from the command:

stdin: is not a tty
dpkg-preconfigure: unable to re-open stdin: No such file or directory

Creating config file /etc/idmapd.conf with new version

Creating config file /etc/default/nfs-common with new version

Creating config file /etc/exports with new version

Creating config file /etc/default/nfs-kernel-server with new version
FATAL: Could not load /lib/modules/4.4.0-31-generic/modules.dep: No such file or directory
mount: block device nfsd is write-protected, mounting read-only
mount: cannot mount block device nfsd read-only
rpc.nfsd: Unable to access /proc/fs/nfsd errno 2 (No such file or directory).
Please try, as root, 'mount -t nfsd nfsd /proc/fs/nfsd' and then restart rpc.nfsd to correct the problem
invoke-rc.d: initscript nfs-kernel-server, action "start" failed.
dpkg: error processing nfs-kernel-server (--configure):
 subprocess installed post-installation script returned error exit status 1
Errors were encountered while processing:
 nfs-kernel-server
E: Sub-process /usr/bin/dpkg returned an error code (1)

==> hypernode: The previous process exited with exit code 1.
```

See @tomlankhorst's related comment on [this issue](https://github.com/ByteInternet/hypernode-vagrant/issues/100)