### PR TITLE
Improve hostpath handling

### DIFF
--- a/lib/vagrant-nfs_guest/action/mount_nfs.rb
+++ b/lib/vagrant-nfs_guest/action/mount_nfs.rb
@@ -42,6 +42,7 @@ module VagrantPlugins
             folders.each do |name, opts|
               if opts[:type] == :nfs_guest
                 nfs_guest = true
+                opts[:hostpath] = File.expand_path(opts[:hostpath], env[:root_path])
               end
             end
 

--- a/lib/vagrant-nfs_guest/action/unmount_nfs.rb
+++ b/lib/vagrant-nfs_guest/action/unmount_nfs.rb
@@ -16,6 +16,12 @@ module VagrantPlugins
             @machine.ui.info(I18n.t("vagrant_nfs_guest.actions.vm.nfs.unmounting"))
             folders = @machine.config.vm.synced_folders
 
+            folders.each do |name, opts|
+              if opts[:type] == :nfs_guest
+                opts[:hostpath] = File.expand_path(opts[:hostpath], env[:root_path])
+              end
+            end
+
             @machine.env.host.capability(:nfs_unmount, @machine.ui, folders)
           end
 

--- a/lib/vagrant-nfs_guest/hosts/bsd/cap/mount_nfs.rb
+++ b/lib/vagrant-nfs_guest/hosts/bsd/cap/mount_nfs.rb
@@ -18,7 +18,6 @@ module VagrantPlugins
                 mount_options = opts.fetch(:mount_options, ["noatime"])
                 nfs_options = mount_options.empty? ? "" : "-o #{mount_options.join(',')}"
 
-                system("mkdir -p #{opts[:hostpath]}")
                 mount_command = "mount -t nfs #{nfs_options} '#{ip}:#{opts[:guestpath]}' '#{opts[:hostpath]}'"
                 if system(mount_command)
                   break

--- a/lib/vagrant-nfs_guest/hosts/bsd/cap/unmount_nfs.rb
+++ b/lib/vagrant-nfs_guest/hosts/bsd/cap/unmount_nfs.rb
@@ -16,8 +16,7 @@ module VagrantPlugins
 
               unmount_options = opts.fetch(:unmount_options, []).join(" ")
 
-              expanded_host_path = `printf #{opts[:hostpath]}`
-              umount_msg = `umount #{unmount_options} '#{expanded_host_path}' 2>&1`
+              umount_msg = `umount #{unmount_options} '#{opts[:hostpath]}' 2>&1`
 
               if $?.exitstatus != 0
                 if not umount_msg.include? 'not currently mounted'

--- a/lib/vagrant-nfs_guest/hosts/linux/cap/mount_nfs.rb
+++ b/lib/vagrant-nfs_guest/hosts/linux/cap/mount_nfs.rb
@@ -18,7 +18,6 @@ module VagrantPlugins
                 mount_options = opts.fetch(:mount_options, ["noatime"])
                 nfs_options = mount_options.empty? ? "" : "-o #{mount_options.join(',')}"
 
-                system("mkdir -p #{opts[:hostpath]}")
                 mount_command = "sudo mount -t nfs #{nfs_options} '#{ip}:#{opts[:guestpath]}' '#{opts[:hostpath]}'"
                 if system(mount_command)
                   break

--- a/lib/vagrant-nfs_guest/hosts/linux/cap/unmount_nfs.rb
+++ b/lib/vagrant-nfs_guest/hosts/linux/cap/unmount_nfs.rb
@@ -16,8 +16,7 @@ module VagrantPlugins
 
               unmount_options = opts.fetch(:unmount_options, []).join(" ")
 
-              expanded_host_path = `printf #{opts[:hostpath]}`
-              umount_msg = `sudo umount #{unmount_options} '#{expanded_host_path}' 2>&1`
+              umount_msg = `sudo umount #{unmount_options} '#{opts[:hostpath]}' 2>&1`
 
               if $?.exitstatus != 0
                 if not umount_msg.include? 'not currently mounted'


### PR DESCRIPTION
This pull request includes the following changes:
1. removes the mkdir instruction: missing hostpaths will be created by vagrant already if the create option is set to true. see https://github.com/Learnosity/vagrant-nfs_guest/issues/38#issuecomment-275043904
2. extends the hostpaths to absolute paths before using them with the mount/umount commands. This is to make sure that the commands work regardless of the current working directory. see #39 
