### PR TITLE
Handle force halts

### DIFF
--- a/lib/vagrant-nfs_guest/action/unmount_nfs.rb
+++ b/lib/vagrant-nfs_guest/action/unmount_nfs.rb
@@ -19,6 +19,14 @@ module VagrantPlugins
             folders.each do |name, opts|
               if opts[:type] == :nfs_guest
                 opts[:hostpath] = File.expand_path(opts[:hostpath], env[:root_path])
+                if env[:force_halt]
+                  # If this is a force halt, force unmount the nfs shares.
+                  opts[:unmount_options] = opts.fetch(:unmount_options, []) << '-f'
+                  # We have to change the working dir if inside a hostmount to prevent "No such file or directory - getcwd" errors.
+                  if Dir.pwd.start_with?(opts[:hostpath])
+                    Dir.chdir("#{opts[:hostpath]}/..")
+                  end
+                end
               end
             end
 


### PR DESCRIPTION
Use the force switch on unmount command if the force switch was specified on the halt command.
This will stop the *force halt* command from being aborted by a failing unmount.