### PR TITLE
Add VMware Fusion provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - NEW: moved to version v1.0.0 as it's no longer a "beta" plugin, it's been well used and tested. So figured now is a good time.
 - NEW: `disabled` flag on shares now are properly respected
 - UPDATED: share directories on guest are no longer recursively `chown`.
+- NEW: Added VMware Fusion provider support.
 - Added untested support for Docker providers (Please raise any issues if they don't work!).
 - Added Parallels provider support
 - Redhat/CentOS guest support added.

--- a/lib/vagrant-nfs_guest/guests/linux/cap/nfs_server.rb
+++ b/lib/vagrant-nfs_guest/guests/linux/cap/nfs_server.rb
@@ -56,14 +56,16 @@ module VagrantPlugins
             machine.guest.capability(:nfs_check_command)
           end
 
-          def self.nfs_export(machine, ip, folders)
+          def self.nfs_export(machine, ips, folders)
             if !nfs_capable?(machine)
                 raise Errors::NFSServerMissing
             end
 
             if machine.guest.capability?(:nfs_setup_firewall)
               machine.ui.info I18n.t("vagrant_nfs_guest.guests.linux.nfs_setup_firewall")
-              machine.guest.capability(:nfs_setup_firewall, ip)
+              ips.each do |ip|
+                machine.guest.capability(:nfs_setup_firewall, ip)
+              end
             end
 
             nfs_exports_template = machine.guest.capability(:nfs_exports_template)
@@ -73,7 +75,7 @@ module VagrantPlugins
             output = Vagrant::Util::TemplateRenderer.render(
               nfs_exports_template,
               uuid: machine.id,
-              ips: [ip],
+              ips: ips,
               folders: folders,
               user: Process.uid)
 

--- a/lib/vagrant-nfs_guest/plugin.rb
+++ b/lib/vagrant-nfs_guest/plugin.rb
@@ -20,6 +20,7 @@ require_relative "providers/virtualbox/plugin"
 require_relative "providers/parallels/plugin"
 require_relative "providers/docker/plugin"
 require_relative "providers/lxc/plugin"
+require_relative "providers/vmware_fusion/plugin"
 
 module VagrantPlugins
   module SyncedFolderNFSGuest

--- a/lib/vagrant-nfs_guest/providers/vmware_fusion/cap/nfs_settings.rb
+++ b/lib/vagrant-nfs_guest/providers/vmware_fusion/cap/nfs_settings.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         def self.read_host_ip
           # In practice, we need the host's IP on the vmnet device this VM uses.
           # It seems a bit tricky to get the right one, so let's allow all.
-          return `ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{ print $2; }'`.split("\n")
+          return `for N in $(ifconfig | awk -F: '/vmnet/ { print $1; }'); do ifconfig $N | awk '/inet / { print $2; }'; done`.split("\n")
         end
 
         def self.nfs_settings(machine)

--- a/lib/vagrant-nfs_guest/providers/vmware_fusion/cap/nfs_settings.rb
+++ b/lib/vagrant-nfs_guest/providers/vmware_fusion/cap/nfs_settings.rb
@@ -1,0 +1,19 @@
+module VagrantPlugins
+  module SyncedFolderNFSGuest
+    module ProviderVMwareFusion
+      module Cap
+        def self.read_host_ip
+          # In practice, we need the host's IP on the vmnet device this VM uses.
+          # It seems a bit tricky to get the right one, so let's allow all.
+          return `ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{ print $2; }'`.split("\n")
+        end
+
+        def self.nfs_settings(machine)
+          host_ip = self.read_host_ip
+          machine_ip = machine.provider.driver.read_ip
+          return host_ip, machine_ip
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-nfs_guest/providers/vmware_fusion/plugin.rb
+++ b/lib/vagrant-nfs_guest/providers/vmware_fusion/plugin.rb
@@ -1,0 +1,15 @@
+require "vagrant"
+
+module VagrantPlugins
+  module SyncedFolderNFSGuest
+    class Plugin < Vagrant.plugin("2")
+      name "vmware_fusion-provider"
+      description "vagrant-vmware_fusion provider"
+
+      provider_capability(:vmware_fusion, :nfs_settings) do
+        require_relative "cap/nfs_settings"
+        ProviderVMwareFusion::Cap
+      end
+    end
+  end
+end

--- a/lib/vagrant-nfs_guest/synced_folder.rb
+++ b/lib/vagrant-nfs_guest/synced_folder.rb
@@ -59,7 +59,7 @@ module VagrantPlugins
         end
 
         machine.ui.info I18n.t("vagrant_nfs_guest.actions.vm.nfs.exporting")
-        machine.guest.capability(:nfs_export, host_ip, mount_folders)
+        machine.guest.capability(:nfs_export, Array(host_ip), mount_folders)
       end
 
       protected

--- a/lib/vagrant-nfs_guest/version.rb
+++ b/lib/vagrant-nfs_guest/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module SyncedFolderNFSGuest
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
Fixes #37.

I spent some time poking around in the methods on `machine.provider.driver`, but none of them really gave me the host IP in an obvious way.

Unfortunately, using SSH_CLIENT (the LXC provider method) also failed, because it gave e.g. `172.16.34.2` instead of `172.16.34.1` which the NFS client ends up trying from - likely because of port forwarding.

Since VMware Fusion is only on Mac, I figured it was safe enough to just read all local IPs, and allow/firewall each of them.

Is that acceptable?  For my purposes, I'm not very concerned with restricting the NFS access beyond the host.